### PR TITLE
Implementation of toFront/toBack methods for controlling zIndex when using dom rendering.

### DIFF
--- a/sprite.js
+++ b/sprite.js
@@ -567,15 +567,22 @@ Sprite.prototype.size = function (w, h) {
 };
 
 Sprite.prototype.toFront = function(){
-	if(this.dom && this.layer){
-		this.layer.dom.appendChild(this.dom);
-	}
+    this.layer.lastZIndex++;
+    return this.setZIndex(this.layer.lastZIndex);
 };
 
 Sprite.prototype.toBack = function(){
-	if(this.dom && this.layer){
-		this.layer.dom.insertBefore(this.dom, this.layer.dom.firstChild);
-	}
+    this.layer.lastZIndex++;
+    return this.setZIndex(-this.layer.lastZIndex);
+};
+
+Sprite.prototype.setZIndex = function(z){
+    if(this.dom && this.layer) {
+        this._dirty.zindex = true;
+        this.changed = true;
+        this.zindex = z;
+    }
+    return this;
 };
 
 // Physic
@@ -747,7 +754,9 @@ Sprite.prototype.update = function updateDomProperties () {
 
     if (this._dirty.color)
         style.backgroundColor = this.color;
-
+	
+	if (this._dirty.zindex)
+        style.zIndex = this.zindex;
 
     if(this._dirty.transform) {
         style[sjs.tproperty + 'Origin'] = this.xTransformOrigin + " " + this.yTransformOrigin;
@@ -1527,7 +1536,9 @@ Layer = function Layer(scene, name, options) {
         // we send back the same.
         return this.scene.layers[name];
     }
-
+	
+	this.lastZIndex = 0;
+	
     domElement = doc.getElementById(name);
     if (!domElement)
         needToCreate = true;


### PR DESCRIPTION
Hello,

Just putting in a pull request for the toFront/toBack methods discussed in the ticket I raised here(https://github.com/batiste/sprite.js/issues/20). The code was revised in regards to batiste's feedback and now uses the z-index to order the sprites (which proved to be significantly faster when tested via a modified particle test). A setZIndex method was also added, which could be used to take more granular control over sprite z ordering within a layer if anyone wished to do so.

It would be great if you'd be willing to merge this in to the main branch, but no worries if its not deemed to be useful enough / you'd rather implement it yourselves in a different way.

Thanks,
Carl
