### PR TITLE
Use cancelAnimationFrame in Ticker.pause() if animation frames are enabled

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -3,4 +3,5 @@ Yoan Blanc
 Szymon Pilkowski
 Cosimo Streppone
 Jonathan Bieler
+Daniel White
 Ground tile by http://www.pixeljoint.com/p/19372.htm

--- a/tests/test_particles.html
+++ b/tests/test_particles.html
@@ -83,7 +83,7 @@ window.onload = function() {
         useReq = req.checked;
         ticker.useAnimationFrame = useReq;
     }
-    if(!sjs.animationFrame)
+    if(!sjs.requestAnimationFrame || !sjs.cancelAnimationFrame)
         req.disabled = "disabled";
 
     var canvas = window.location.href.indexOf('canvas') != -1;


### PR DESCRIPTION
This is implemented by capturing the callback reference returned by
requestAnimationFrame which can be cancelled in a similar manner to
clearing a timeout.

Prior to this, Ticker.pause() would clear sjs.animationFrame and then
a null reference error would be triggered when resuming.
